### PR TITLE
Minor changes

### DIFF
--- a/OmniMIDIDebugWindow/OmniMIDIDebugWindow/OSInfo.cs
+++ b/OmniMIDIDebugWindow/OmniMIDIDebugWindow/OSInfo.cs
@@ -159,9 +159,10 @@ namespace OmniMIDIDebugWindow
             get
             {
                 string servicePack = String.Empty;
-                OSVERSIONINFOEX osVersionInfo = new OSVERSIONINFOEX();
-
-                osVersionInfo.dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX));
+                OSVERSIONINFOEX osVersionInfo = new OSVERSIONINFOEX
+                {
+                    dwOSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX))
+                };
 
                 if (GetVersionEx(ref osVersionInfo))
                 {

--- a/OmniMIDIDebugWindow/OmniMIDIDebugWindow/OmniMIDIDebugWindow.cs
+++ b/OmniMIDIDebugWindow/OmniMIDIDebugWindow/OmniMIDIDebugWindow.cs
@@ -431,7 +431,7 @@ namespace OmniMIDIDebugWindow
 
                 COS.Text = String.Format("{0} ({1}, {2})", OSInfo.Name.Replace("Microsoft ", ""), FullVersion, bit);
                 CPU.Text = String.Format("{0} ({1} architecture)", cpuname, cpubit);
-                CPUInfo.Text = String.Format("{0}, {1}/{2} cores, {3} ({4}MHz)", cpumanufacturer, coreCount, Environment.ProcessorCount, Frequency, cpuclock);
+                CPUInfo.Text = String.Format("{0}, {1} cores, {2} threads, {3} ({4}MHz)", cpumanufacturer, coreCount, Environment.ProcessorCount, Frequency, cpuclock);
                 GPU.Text = gpuname;
                 GPUInternalChip.Text = gpuchip;
                 GPUInfo.Text = String.Format("{0}MB VRAM, driver version {1}", (gpuvram / 1048576), gpuver);
@@ -561,7 +561,7 @@ namespace OmniMIDIDebugWindow
         {
             try
             {
-                if (DebugName(Value).Equals("OMDirect")) ValueToChange = Convert.ToInt32(DebugValue(Value));
+                if (DebugName(Value).Equals(RequestedValue)) ValueToChange = Convert.ToInt32(DebugValue(Value));
                 return true;
             }
             catch { return false; }
@@ -665,6 +665,7 @@ namespace OmniMIDIDebugWindow
 
         private void GetInfo()
         {
+            this.DebugInfo.Interval = 10;
             if (Tabs.SelectedIndex == 0)
             {
                 // Time to write all the stuff to the string builder
@@ -768,8 +769,8 @@ namespace OmniMIDIDebugWindow
             }
             else if (Tabs.SelectedIndex == 2)
             {
-                TM.Text = String.Format("{0} ({1} bytes)", (tlmem / (1024 * 1024) + "MB").ToString(), tlmem.ToString("N0", System.Globalization.CultureInfo.GetCultureInfo("de")));
-                AM.Text = String.Format("{0} ({1:0.#}%, {2} bytes)", (avmem / (1024 * 1024) + "MB").ToString(), Math.Round(percentage, 1).ToString(), avmem.ToString("N0", System.Globalization.CultureInfo.GetCultureInfo("de")));
+                this.DebugInfo.Interval = 1000;
+                AM.Text = String.Format("{0} ({1:0.#}%, {2} bytes)", (avmemint + "MB").ToString(), Math.Round(percentage, 1).ToString(), avmem.ToString("N0", CultureInfo.GetCultureInfo("de")));
             }
         }
 
@@ -912,15 +913,16 @@ namespace OmniMIDIDebugWindow
         static double percentage = 0.0;
         private void CheckMem_DoWork(object sender, DoWorkEventArgs e)
         {
-            ComputerInfo CI = new ComputerInfo();
+            CI = new ComputerInfo();
+            tlmem = CI.TotalPhysicalMemory;
+            tlmemint = tlmem / (1024 * 1024);
+            TM.Text = String.Format("{0} ({1} bytes)", (tlmemint + "MB").ToString(), tlmem.ToString("N0", System.Globalization.CultureInfo.GetCultureInfo("de")));
             while (CI != null)
             {
                 avmem = CI.AvailablePhysicalMemory;
-                tlmem = CI.TotalPhysicalMemory;
                 avmemint = avmem / (1024 * 1024);
-                tlmemint = tlmem / (1024 * 1024);
                 percentage = avmem * 100.0 / tlmem;
-                Thread.Sleep(50);
+                Thread.Sleep(DebugInfo.Interval);
             }
         }
     }

--- a/OmniMIDIDebugWindow/OmniMIDIDebugWindow/Program.cs
+++ b/OmniMIDIDebugWindow/OmniMIDIDebugWindow/Program.cs
@@ -82,15 +82,13 @@ namespace OmniMIDIDebugWindow
         public const short PROCESSOR_ARCHITECTURE_INTEL = 0;
 
         public static uint BringToFrontMessage;
-        static EventWaitHandle m;
         public static Int32 SelectedDebugVal = 1;
 
         [STAThread]
         static void Main()
         {
-            bool ok;
             BringToFrontMessage = WinAPI.RegisterWindowMessage("OmniMIDIDebugWindowToFront");
-            m = new EventWaitHandle(false, EventResetMode.ManualReset, "OmniMIDIDebugWindow", out ok);
+            new EventWaitHandle(false, EventResetMode.ManualReset, "OmniMIDIDebugWindow", out bool ok);
             if (!ok)
             {
                 WinAPI.PostMessage((IntPtr)WinAPI.HWND_BROADCAST, BringToFrontMessage, IntPtr.Zero, IntPtr.Zero);
@@ -110,9 +108,8 @@ namespace OmniMIDIDebugWindow
             {
                 Int32 Found = 0;
                 String PipeToAdd;
-                WIN32_FIND_DATA lpFindFileData;
 
-                IntPtr ptr = FindFirstFile(@"\\.\pipe\*", out lpFindFileData);
+                IntPtr ptr = FindFirstFile(@"\\.\pipe\*", out WIN32_FIND_DATA lpFindFileData);
                 PipeToAdd = Path.GetFileName(lpFindFileData.cFileName);
                 if (PipeToAdd.Contains("OmniMIDIDbg"))
                 {

--- a/OmniMIDIDebugWindow/OmniMIDIDebugWindow/TimerFuncs.cs
+++ b/OmniMIDIDebugWindow/OmniMIDIDebugWindow/TimerFuncs.cs
@@ -38,9 +38,10 @@ namespace OmniMIDIDebugWindow
         public static void MicroSleep(Int64 MicroSec)
         {
             IntPtr timer;
-            LARGE_INTEGER ft = new LARGE_INTEGER();
-
-            ft.QuadPart = -(10 * MicroSec);
+            LARGE_INTEGER ft = new LARGE_INTEGER
+            {
+                QuadPart = -(10 * MicroSec)
+            };
 
             timer = CreateWaitableTimer(IntPtr.Zero, true, null);
             SetWaitableTimer(timer, ref ft, 0, null, IntPtr.Zero, false);


### PR DESCRIPTION
1) Changed CPUInfo text from "{1}/{2} cores" to "{1} cores, {2} threads. ( "4 cores, 8 threads" instead of "4/8 cores )
2) ReadPipeBoolean uses "RequestedValue"
3) Changed DebugInfo.Interval to 1000 when on SelectedIndex 2, otherwise changed it to 10 ( Instead of 1ms everywhere )
4) Total memory only updates on start
5) CheckMem_DoWork
  A) Changed sleep time to DebugInfo's Interval
  B) Total memory is only asked once
  C) tlmemint, and avmemint used
6) Reduced the number of Visual Studio Messages
  ( Private member never used
    Variable declaration can be inlined
    Object initialization can be simplified )